### PR TITLE
fixed name of the demo GreetCommand in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ based on [Symfony2][1] components:
 require_once __DIR__.'/cilex.phar';
 
 $app = new \Cilex\Application('Cilex');
-$app->command(new \Cilex\Command\DemoGreetCommand());
+$app->command(new \Cilex\Command\GreetCommand());
 $app->run();
 ```
 


### PR DESCRIPTION
There was a small issue with the name of the GreetCommand in the README. I just fixed this :)
