### PR TITLE
Fixed broken composer.json file - additional comma causing parse errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console":      "2.1.*",
 
         "symfony/process":      "2.1.*",
-        "symfony/finder":       "2.1.*",
+        "symfony/finder":       "2.1.*"
     },
     "suggest":{
         "monolog/monolog":   ">=1.0.0",


### PR DESCRIPTION
Mike there is a parse error in composer.json. Here's fix.
