### PR TITLE
Compiler bugfix

### DIFF
--- a/src/Cilex/Compiler.php
+++ b/src/Cilex/Compiler.php
@@ -64,10 +64,8 @@ class Compiler
         }
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../LICENSE'), false);
-		
-        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload.php'));
-		
-		$this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload.php'));
+
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/ClassLoader.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_namespaces.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_classmap.php'));


### PR DESCRIPTION
Although .composer/autoload.php triggered an error the method is deprecated, the Compiler stil included the .composer files.
This PR changes the Compiler to use the new directory.
