### PR TITLE
Fixed compiler script. Included all the autoloading required files

### DIFF
--- a/src/Cilex/Compiler.php
+++ b/src/Cilex/Compiler.php
@@ -67,9 +67,10 @@ class Compiler
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/ClassLoader.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_real.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_namespaces.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/composer/autoload_classmap.php'));
-		
+
         // Stubs
         $phar->setStub($this->getStub());
 


### PR DESCRIPTION
The compiler script was missing the inclusion of the autoload_real.php file causing the compiling process to be incomplete and any further attempt to use the phar file to fail.
