### PR TITLE
Updating .travis.yml to use pre-installed composer command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ php:
   - 5.4
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install
+  - composer install
 
 script: phpunit --coverage-text
 


### PR DESCRIPTION
As every travis vm comes with composer pre-installed, there is no need to download it from getcomposer every time. Using the pre-defined command is faster, saves bandwith and does work when getcomposer is not reachable for some reason.
