### PR TITLE
Fix lost library class-loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "pimple/pimple":        "1.0.*",
         "symfony/console":      "2.1.*",
         "symfony/process":      "2.1.*",
-        "symfony/finder":       "2.1.*",
-        "symfony/class-loader": "2.1.*"
+        "symfony/finder":       "2.1.*"
     },
     "require-dev":{
         "symfony/validator": "2.1.*"

--- a/src/Cilex/Compiler.php
+++ b/src/Cilex/Compiler.php
@@ -55,7 +55,6 @@ class Compiler
             ->notName('Compiler.php')
             ->in(__DIR__.'/..')
             ->in(__DIR__.'/../../vendor/pimple/pimple/lib')
-            ->in(__DIR__.'/../../vendor/symfony/class-loader/Symfony/Component/ClassLoader')
             ->in(__DIR__.'/../../vendor/symfony/console/Symfony/Component/Console')
         ;
 


### PR DESCRIPTION
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message 'The "/src/Cilex/../../vendor/symfony/class-loader/Symfony/Component/ClassLoader" directory does not exist.' in /vendor/symfony/finder/Symfony/Component/Finder/Finder.php:497
