### PR TITLE
[WIP] Use Cilex Pimple Console Service Provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,19 @@
     "authors":[
         { "name":  "Mike van Riel", "email": "mike.vanriel@naenius.com" }
     ],
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/simensen/cilex-console-service-provider.git"
+        }
+    ],
     "require":{
-        "php":             ">=5.3.3",
-        "pimple/pimple":   "1.0.*",
-        "symfony/console": "2.1.*",
-        "symfony/process": "2.1.*",
-        "symfony/finder":  "2.1.*"
+        "php":                            ">=5.3.3",
+        "pimple/pimple":                  "1.0.*",
+        "symfony/console":                "2.1.*",
+        "symfony/process":                "2.1.*",
+        "symfony/finder":                 "2.1.*",
+        "cilex/console-service-provider": "1.*@dev"
     },
     "require-dev":{
         "symfony/validator": "2.1.*"

--- a/composer.lock
+++ b/composer.lock
@@ -1,6 +1,57 @@
 {
-    "hash": "944309f818ae516a3e9dadc903ed7bf7",
+    "hash": "e56c1e12a86395d16852822216dd72f4",
     "packages": [
+        {
+            "name": "cilex/console-service-provider",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/simensen/cilex-console-service-provider.git",
+                "reference": "0d3585c1915f12dbe60ad5a698ab466f2b6a5233"
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "pimple/pimple": "1.*@dev",
+                "symfony/console": "~2.1"
+            },
+            "require-dev": {
+                "cilex/cilex": "1.*@dev",
+                "silex/silex": "1.*@dev"
+            },
+            "time": "1353948732",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "installation-source": "source",
+            "autoload": {
+                "psr-0": {
+                    "Cilex\\Pimple\\Provider\\Console": "src"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com"
+                }
+            ],
+            "description": "Console Service Provider",
+            "keywords": [
+                "pimple",
+                "cilex",
+                "silex",
+                "console"
+            ]
+        },
         {
             "name": "pimple/pimple",
             "version": "1.0.0",
@@ -189,12 +240,70 @@
             "homepage": "http://symfony.com"
         }
     ],
-    "packages-dev": null,
+    "packages-dev": [
+        {
+            "name": "symfony/validator",
+            "version": "v2.1.3",
+            "target-dir": "Symfony/Component/Validator",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Validator",
+                "reference": "v2.1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/symfony/Validator/zipball/v2.1.3",
+                "reference": "v2.1.3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/http-foundation": "2.1.*",
+                "symfony/locale": "2.1.*",
+                "symfony/yaml": "2.1.*"
+            },
+            "suggest": {
+                "doctrine/common": ">=2.1,<2.4-dev",
+                "symfony/http-foundation": "2.1.*",
+                "symfony/yaml": "2.1.*"
+            },
+            "time": "2012-10-22 07:37:12",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Validator": ""
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Validator Component",
+            "homepage": "http://symfony.com"
+        }
+    ],
     "aliases": [
 
     ],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ]
+    "stability-flags": {
+        "cilex/console-service-provider": 20
+    }
 }

--- a/src/Cilex/Application.php
+++ b/src/Cilex/Application.php
@@ -12,6 +12,7 @@
 namespace Cilex;
 
 use \Symfony\Component\Console;
+use \Cilex\Pimple\Provider\Console\Adapter\Cilex\ConsoleServiceProvider;
 
 /**
  * The Cilex framework class.
@@ -35,11 +36,13 @@ class Application extends \Pimple
      */
     public function __construct($name, $version = null)
     {
-        $this['console'] = $this->share(
-            function () use ($name, $version) {
-                return new Console\Application($name, $version);
-            }
+        $consoleConfig = array(
+            'console.name' => $name,
         );
+        if (null !== $version) {
+            $consoleConfig['console.version'] = $version;
+        }
+        $this->register(new ConsoleServiceProvider, $consoleConfig);
     }
 
     /**
@@ -70,9 +73,8 @@ class Application extends \Pimple
      *
      * @return void
      */
-    public function command(Command\Command $command)
+    public function command(Console\Command\Command $command)
     {
-        $command->setContainer($this);
         $this['console']->add($command);
     }
 

--- a/src/Cilex/Command/Command.php
+++ b/src/Cilex/Command/Command.php
@@ -23,30 +23,13 @@ use \Symfony\Component\Console;
 abstract class Command extends Console\Command\Command
 {
     /**
-     * @var \Cilex\Application
-     */
-    protected $container = null;
-
-    /**
-     * Sets the application container containing all services.
-     *
-     * @param \Cilex\Application $container Application object to register.
-     *
-     * @return void
-     */
-    public function setContainer(\Cilex\Application $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
      * Returns the application container.
      *
      * @return \Cilex\Application
      */
     public function getContainer()
     {
-        return $this->container;
+        return $this->getApplication()->getContainer();
     }
 
     /**
@@ -67,6 +50,6 @@ abstract class Command extends Console\Command\Command
      */
     public function getService($name)
     {
-        return isset($this->container[$name]) ? $this->container[$name] : null;
+        return $this->getApplication()->getService($name);
     }
 }

--- a/src/Cilex/Command/DemoInfoCommand.php
+++ b/src/Cilex/Command/DemoInfoCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Cilex framework.
+ *
+ * (c) Mike van Riel <mike.vanriel@naenius.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Cilex\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command as BaseCommand;
+
+/**
+ * Example command for testing purposes.
+ */
+class DemoInfoCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('demo:info')
+            ->setDescription('Get Application Information');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // This is a contrived example to show accessing services
+        // from the container without needing the command itself
+        // to extend from anything but Symfony Console's base Command.
+
+        $app = $this->getApplication()->getService('console');
+
+        $output->writeln('Name: ' . $app->getName());
+        $output->writeln('Version: ' . $app->getVersion());
+    }
+}

--- a/tests/Cilex/Tests/Command/CommandTest.php
+++ b/tests/Cilex/Tests/Command/CommandTest.php
@@ -34,16 +34,13 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests the getContainer and setContainer methods to see whether the
-     * provided Cilex Application is persisted.
+     * Tests the getContainer method.
      */
     public function testContainer()
     {
         $app = new \Cilex\Application('Test');
+        $app->command($this->fixture);
 
-        $this->assertNull($this->fixture->getContainer());
-
-        $this->fixture->setContainer($app);
         $this->assertSame($app, $this->fixture->getContainer());
     }
 
@@ -54,11 +51,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testGetService()
     {
         $app = new \Cilex\Application('Test');
-        $this->fixture->setContainer($app);
+        $app->command($this->fixture);
 
         $this->assertInstanceOf(
             '\Symfony\Component\Console\Application',
-            $app['console']
+            $this->fixture->getService('console')
         );
     }
 }


### PR DESCRIPTION
As discussed with @mvriel, I am working on extracting the Console service from Cilex itself into an external Pimple service provider that can be reused by any Pimple application (like Silex).

This PR removes the Console service creation from `Cilex\Application` and instead uses a standalone Console service provider. You can find that service provider [here](https://github.com/simensen/cilex-console-service-provider).

The intention is that the standalone Console service provider will fall under the Cilex namespace. Since it does not exist yet it is living under my account while I work on it. (@mvriel requested it be under \Cilex)

A few things...

I would like to propose migrating away from relying on `Cilex\Command\Command` as it would tie any commands based on it to Cilex. As this is all about reusability across the Pimple ecosystem, the sooner we are making Pimple things instead of Silex/Cilex/Whateverlex things, the better.

There is a mechanism for getting access to the underlying Pimple Container via `$this->getApplication()->getContainer()`, similar to how Symfony Framework Bundle is setup. This should make it trivial to port things like the Doctrine commands to the Pimple ecosystem in one go rather than having to do it for each project (Silex, Cilex, etc.).

Any command can now be registered to Cilex via `$app->command()`, even those that are not specifically made for Cilex.

The tests work and my sample application works as expected:

``` php
<?php

require_once __DIR__.'/vendor/autoload.php';

$app = new \Cilex\Application('Cilex');
$app->command(new \Cilex\Command\GreetCommand());
$app->command(new \Cilex\Command\DemoInfoCommand());
$app->run();
```

In theory this should be BC with existing projects but I'm new to the Cilex ecosystem so I'm not sure exactly how people are using it.

For a service provider that wants to expose commands in a Pimple portable way, it can be done like this:

``` php
<?php
$app['console'] = $app->share($app->extend('console', function($console, $app) {
    $console->addCommand(new MyReusableCommand);

    return $console;
}));
```

---

The background on this is that I've been trying to port some console commands from DoctrineBundle and DoctrineMigrationsBundle to Silex. I brought up the idea of a Console service provider and having a Silex specific subclass of Console Application as an RFC (here: fabpot/Silex#542).

Shortly after I started looking at Cilex and realized that Cilex was providing a `$app['console']` service more or less like I was proposing. I found @mvriel on IRC and proposed simply moving Cilex's Console service stuff to an external provider so that Cilex, Silex, and any Pimple based application could share the "Console as a service" functionality.
