### PR TITLE
Add autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,11 @@
     "keywords":    ["microframework","cli"],
     "homepage":    "http://cilex.github.com",
     "license":     "MIT",
-    "autoload":{
-        "psr-0":{ "Cilex": "src/" }
-    },
     "authors":[
         { "name":  "Mike van Riel", "email": "mike.vanriel@naenius.com" }
     ],
     "autoload": {
-        "PSR-0": {
-            "src/": "Cilex"
-        }
+        "classmap": [ "src/" ]
     },
     "require":{
         "php":             ">=5.3.3",


### PR DESCRIPTION
I usually don't compile a .phar file but rely on cilex/cilex in my composer.json.

In this case it would be nice to have the autoloader present.
