### PR TITLE
Fixed constructor warning

### DIFF
--- a/src/Cilex/Application.php
+++ b/src/Cilex/Application.php
@@ -36,6 +36,7 @@ class Application extends \Pimple
      */
     public function __construct($name, $version = null)
     {
+        parent::__construct();
         $consoleConfig = array('console.name' => $name);
         if (null !== $version) {
             $consoleConfig['console.version'] = $version;


### PR DESCRIPTION
Fixes php warning due to missing `super` call. see #30 
