### PR TITLE
Added console-service-provider to the phar compiler finder.

### DIFF
--- a/src/Cilex/Compiler.php
+++ b/src/Cilex/Compiler.php
@@ -55,6 +55,7 @@ class Compiler
             ->notName('Compiler.php')
             ->in(__DIR__.'/..')
             ->in(__DIR__.'/../../vendor/pimple/pimple/lib')
+            ->in(__DIR__.'/../../vendor/cilex/console-service-provider')
             ->in(__DIR__.'/../../vendor/symfony/console/Symfony/Component/Console');
 
         foreach ($finder as $file) {


### PR DESCRIPTION
Added the console-service-provider library to the finder that compiles the phar, fixes this exception I was always getting:
PHP Fatal error:  Class 'Cilex\Provider\Console\ConsoleServiceProvider' not found in phar://
