### PR TITLE
Add support for symfony2.2 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require":{
         "php":                            ">=5.3.3",
         "pimple/pimple":                  "1.0.*",
-        "symfony/process":                "2.1.*",
-        "symfony/finder":                 "2.1.*",
+        "symfony/process":                "~2.1.0",
+        "symfony/finder":                 "~2.1.0",
         "cilex/console-service-provider": "1.*@dev"
     },
     "require-dev":{
-        "symfony/validator": "2.1.*",
+        "symfony/validator": "~2.1.0",
         "phpunit/phpunit":   "3.7.*"
     },
     "suggest":{

--- a/src/Cilex/Provider/ValidatorServiceProvider.php
+++ b/src/Cilex/Provider/ValidatorServiceProvider.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Validator;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
+use Symfony\Component\Validator\DefaultTranslator;
 
 /**
  * Symfony Validator component Provider.
@@ -36,7 +37,8 @@ class ValidatorServiceProvider implements ServiceProviderInterface
             function () use ($app) {
                 return new Validator(
                     $app['validator.mapping.class_metadata_factory'],
-                    $app['validator.validator_factory']
+                    $app['validator.validator_factory'],
+                    $app['validator.default_translator']
                 );
             }
         );
@@ -50,6 +52,16 @@ class ValidatorServiceProvider implements ServiceProviderInterface
         $app['validator.validator_factory'] = $app->share(
             function () {
                 return new ConstraintValidatorFactory();
+            }
+        );
+
+        $app['validator.default_translator'] = $app->share(
+            function () {
+                if (!class_exists('Symfony\\Component\\Validator\\DefaultTranslator')){
+                    return array();
+                }
+                
+                return new DefaultTranslator();
             }
         );
 


### PR DESCRIPTION
The constructor method signature for
`Symfony\Component\Validator\Validator` has changed in symfony2.2.
It now requires an instance of
`Symfony\Component\Translation\TranslatorInterface` which will break
in symfony2.1
Hence we sniff for the existence of the class(ugly, but I don't see
another way unless you maintain separate branches but that seems silly for something that isn't a symfony bundle)
Also update composer.json to allow symfony > 2.1

All tests pass when using symfony components 2.1 and 2.2

Comments welcome
