### PR TITLE
Update composer.json to allow symfony component versions > 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require":{
         "php":                            ">=5.3.3",
         "pimple/pimple":                  "1.0.*",
-        "symfony/process":                "~2.1.0",
-        "symfony/finder":                 "~2.1.0",
+        "symfony/process":                "~2.1",
+        "symfony/finder":                 "~2.1",
         "cilex/console-service-provider": "1.*@dev"
     },
     "require-dev":{
-        "symfony/validator": "~2.1.0",
+        "symfony/validator": "~2.1",
         "phpunit/phpunit":   "3.7.*"
     },
     "suggest":{


### PR DESCRIPTION
I made a mistake with the syntax in the composer.json file in this PR: https://github.com/Cilex/Cilex/pull/37

This PR fixes that and actually allows installing Cilex with symfony 2.2 components
