### PR TITLE
Depend on a stable version of cilex/console-service-provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "pimple/pimple":                  "1.0.*",
         "symfony/process":                "~2.1",
         "symfony/finder":                 "~2.1",
-        "cilex/console-service-provider": "1.*@dev"
+        "cilex/console-service-provider": "~1.0"
     },
     "require-dev":{
         "symfony/validator": "~2.1",


### PR DESCRIPTION
This is especially useful when Cilex is a sub dependency (dependency of a dependency) in another project. This change means it will no longer be necessary to set the stability to dev in the parent project.
