### PR TITLE
Add easy way to use simple closures as commands

### DIFF
--- a/src/Cilex/Application.php
+++ b/src/Cilex/Application.php
@@ -109,12 +109,27 @@ class Application extends \Pimple\Container
      *
      * If a command with the same name already exists, it will be overridden.
      *
-     * @param \Cilex\Command\Command $command A Command object
+     * @param Command $command A Command object
      * @api
      * @return void
      */
-    public function command(Command $command)
+    public function add(Command $command)
     {
         $this['console']->add($command);
+    }
+
+    /**
+     * @param string $name
+     * @param callable $callable
+     * @return Command
+     */
+    public function command($name, $callable)
+    {
+        $command = new Command($name);
+        $command->setCode($callable);
+
+        $this->add($command);
+
+        return $command;
     }
 }

--- a/tests/Cilex/Tests/ApplicationTest.php
+++ b/tests/Cilex/Tests/ApplicationTest.php
@@ -57,6 +57,24 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testClosureCommand()
+    {
+        $invoked = false;
+        $command = $this->app->command('closure-command', function () use (&$invoked) {
+            $invoked = true;
+        });
+
+        $this->assertInstanceOf('Symfony\Component\Console\Command\Command', $command);
+        $this->assertTrue($this->app['console']->has('closure-command'));
+
+        $command->run(
+            $this->getMock('Symfony\Component\Console\Input\InputInterface'),
+            $this->getMock('Symfony\Component\Console\Output\OutputInterface')
+        );
+
+        $this->assertTrue($invoked);
+    }
+
     /**
      * Tests the command method to see if the command is properly set and the
      * Cilex application is added as container.
@@ -65,7 +83,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->app['console']->has('demo:greet'));
 
-        $this->app->command(new GreetCommand());
+        $this->app->add(new GreetCommand());
 
         $this->assertTrue($this->app['console']->has('demo:greet'));
 

--- a/tests/Cilex/Tests/Command/CommandTest.php
+++ b/tests/Cilex/Tests/Command/CommandTest.php
@@ -40,7 +40,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testContainer()
     {
         $app = new Application('Test');
-        $app->command($this->fixture);
+        $app->add($this->fixture);
 
         $this->assertSame($app, $this->fixture->getContainer());
     }
@@ -52,7 +52,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testGetService()
     {
         $app = new Application('Test');
-        $app->command($this->fixture);
+        $app->add($this->fixture);
 
         $this->assertInstanceOf('Symfony\Component\Console\Application', $this->fixture->getService('console'));
     }


### PR DESCRIPTION
This fixed #27

I know this is a BC but since it targets 2.0 i think it is okay.

The reason for renaming command to add is that it adds the command to the application, which is the same terminology used by a normal Console Application. Also when using closures the name `command` feels more natural.

here is an example, the syntax should be equal to the one used in Silex with its `get`, `post` etc functions.

``` php
<?php

$cilex = new Cilex\Application;
$cilex->command('my-command-name', function ($input, $output) {
    // do something
});

$command = $cilex->command('my-command-name', function ($input, $output) {
    // do something
});

$command->addOption(); // etc.
```