### PR TITLE
Update Pimple for use Pimple2 refs #65 #63

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require" : {
         "php"                      : ">=5.3.3",
         "pimple/pimple"            : "3.0.0",
-        "silex/api"                : "2.0.x-dev",
         "symfony/process"          : "~2.4",
         "symfony/console"          : "~2.4",
         "symfony/event-dispatcher" : "~2.4"


### PR DESCRIPTION
Update Pimple without use alias and directly the good tags, because Composer cannot choices between Pimple 2.1.0 and 2.1.1 for Silex/api

```
 Problem 1
    - silex/api 2.0.x-dev requires pimple/pimple ~2.1 -> satisfiable by pimple/pimple[v2.1.0, v2.1.1].
    - Can only install one of: pimple/pimple[v3.0.0, v2.1.0].
    - Can only install one of: pimple/pimple[v3.0.0, v2.1.1].
    - cilex/cilex dev-develop requires pimple/pimple 3.0.0 as 2.1.0 -> satisfiable by pimple/pimple[v3.0.0].
    - cilex/cilex dev-develop requires silex/api 2.0.x-dev -> satisfiable by silex/api[2.0.x-dev].
    - Installation request for cilex/cilex dev-develop -> satisfiable by cilex/cilex[dev-develop].
```
