### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Read the [documentation][4] for more information.
 ## Usage
 
  - Download composer: `curl -s https://getcomposer.org/installer | php`
- - Add to your dependencies:  `php composer.phar require cilex/cilex dev-master`
+ - Add to your dependencies:  `php composer.phar require cilex/cilex dev-develop`
  - Update the dependencies
  - Create a `run.php` file
 


### PR DESCRIPTION
With dev-master constraint it fails with 
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for cilex/cilex dev-master -> satisfiable by cilex/cilex[dev-master].
    - cilex/cilex dev-master requires pimple/pimple ~1.0 -> satisfiable by pimple/pimple[1.0.0, 1.1.x-dev, v1.0.1, v1.0.2, v1.1.0, v1.1.1] but these conflict with your requirements or minimum-stability.
```
while `dev-develop` constraint works without any troubles ans installation successfully finishes. 