### PR TITLE
Upgraded required PHPUnit to 5.7 (for php 5) and 6 (for php 7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.1
   - hhvm
 
 before_script:
   - composer install
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
 
     "require-dev" : {
-        "phpunit/phpunit" : "~3.7"
+        "phpunit/phpunit" : "^4.8.35 || ^5.7 || ^6.0"
     },
 
     "suggest" : {

--- a/tests/Cilex/Tests/ApplicationTest.php
+++ b/tests/Cilex/Tests/ApplicationTest.php
@@ -13,16 +13,20 @@ namespace Cilex\Tests;
 
 use Cilex\Application;
 use Cilex\Command\GreetCommand;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Application test cases.
  *
  * @author Mike van Riel <mike.vanriel@naenius.com>
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     const NAME    = 'Test';
     const VERSION = '1.0.1';
+
+    /** @var  Application */
+    private $app;
 
     /**
      * Sets up the test app.
@@ -46,10 +50,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomInputOutput()
     {
-        $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
 
-        $this->app['console'] = $this->getMock('Symfony\Component\Console\Application');
+        $this->app['console'] = $this->createMock('Symfony\Component\Console\Application');
         $this->app['console']->expects($this->once())->method('run')->with($input, $output);
 
 
@@ -68,8 +72,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->app['console']->has('closure-command'));
 
         $command->run(
-            $this->getMock('Symfony\Component\Console\Input\InputInterface'),
-            $this->getMock('Symfony\Component\Console\Output\OutputInterface')
+            $this->createMock('Symfony\Component\Console\Input\InputInterface'),
+            $this->createMock('Symfony\Component\Console\Output\OutputInterface')
         );
 
         $this->assertTrue($invoked);
@@ -90,4 +94,21 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->app, $this->app['console']->get('demo:greet')->getContainer());
     }
 
+    /**
+     * Returns a test double for the specified class.
+     *
+     * This method ensures compatibility with PHPUnit 4 and can be removed as soon as PHPUnit 4 is not used anymore.
+     *
+     * @param string $originalClassName
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName)
+    {
+        return $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
 }

--- a/tests/Cilex/Tests/Command/CommandTest.php
+++ b/tests/Cilex/Tests/Command/CommandTest.php
@@ -11,19 +11,20 @@
 
 namespace Cilex\Tests\Command;
 
-use Cilex\Command;
 use Cilex\Application;
+use Cilex\Provider\Console\Command;
+use PHPUnit\Framework\TestCase;
 
-class CommandMock extends \Cilex\Provider\Console\Command {}
+class CommandMock extends Command {}
 
 /**
  * Command\Command test cases.
  *
  * @author Mike van Riel <mike.vanriel@naenius.com>
  */
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
-    /** @var \Cilex\Command\Command */
+    /** @var Command */
     protected $fixture = null;
 
     /**


### PR DESCRIPTION
Greetings from the #SymfonyConHackday2017. This PR upgrades the PHPUnit version that is run for the test suite.