### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,21 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.1
   - hhvm
+
+matrix:
+  include:
+    - php: 7.1
+      env: DEPENDENCIES=beta
+
+before_install:
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
 
 before_script:
   - composer install
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,8 @@
         "php"                      : ">=5.5.9",
         "pimple/pimple"            : "^3.0",
         "silex/api"                : "^2.0",
-        "symfony/process"          : "^2.7 || ^3.0",
-        "symfony/console"          : "^2.7 || ^3.0",
-        "symfony/event-dispatcher" : "^2.7 || ^3.0"
+        "symfony/console"          : "^2.7 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher" : "^2.7 || ^3.0 || ^4.0"
     },
 
     "require-dev" : {

--- a/src/Cilex/Provider/ConsoleServiceProvider.php
+++ b/src/Cilex/Provider/ConsoleServiceProvider.php
@@ -27,7 +27,9 @@ class ConsoleServiceProvider implements \Pimple\ServiceProviderInterface
     public function register(Container $pimple)
     {
         $pimple['console'] = function($pimple) {
-            $console = new ContainerAwareApplication($pimple['console.name'], $pimple['console.version']);
+            $name = $pimple['console.name'] ?: 'UNKNOWN';
+            $version = $pimple['console.version'] ?: 'UNKNOWN';
+            $console = new ContainerAwareApplication($name, $version);
             $console->setDispatcher($pimple['dispatcher']);
             $console->setContainer($pimple);
 


### PR DESCRIPTION
Greetings from the #SymfonyConHackday2017. This PR fixes a small compatibility problem with Symfony 4 and updates the composer.json file to allow the installation of Symfony 4 components.