### PR TITLE
Determine command classes automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Read the [documentation][4] for more information.
 ## Usage
 
  - Create your new commands in `src/Cilex/Command/`
- - Add your new commands to `bin/run.php`
  - Run the commands as:
 ```sh
 ./bin/run.php demo:greet world

--- a/bin/run.php
+++ b/bin/run.php
@@ -6,10 +6,12 @@ if (!$loader = include __DIR__ . '/../vendor/autoload.php') {
 }
 
 $app = new \Cilex\Application('Cilex');
-$app->command(new \Cilex\Command\GreetCommand());
-$app->command(new \Cilex\Command\DemoInfoCommand());
-$app->command('foo', function ($input, $output) {
-    $output->writeln('Example output');
-});
+
+foreach (glob(__DIR__ .'/../src/Cilex/Command/*.php') as $commandFile) {
+    $i = pathinfo($commandFile);
+    $className = $i['filename'];
+    $className = '\Cilex\Command\\' . $className;
+    $app->command(new $className());
+}
 
 $app->run();


### PR DESCRIPTION
Use the command class filenames to automatically add commands to the app.

Users no-longer need to add each command class to run.php manually